### PR TITLE
fix: PointNBytesFlag, DataLinkControlFucntionCodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,10 @@
 export PATH := $(HOME)/go/bin:$(PATH)
 
 setup:
-	git config core.hooksPath .githooks
-	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.7.2
 	go install golang.org/x/tools/cmd/stringer@latest
+	sudo apt-get install -y libpcap-dev
+	git config core.hooksPath .githooks
 
 generate: .generated-canary
 
@@ -21,7 +22,7 @@ lint: generate
 	golangci-lint run ./...
 
 test: generate
-	go test ./dnp3 -v -args -pcaps=opendnp3_test1.pcap
+	CGO_ENABLED=1 go test ./dnp3 -v -args -pcaps=opendnp3_test1.pcap
 
 clean:
 	rm -f *_string.go .generated-canary

--- a/dnp3/data.go
+++ b/dnp3/data.go
@@ -62,9 +62,12 @@ func (ad *ApplicationData) String() string {
 		output += header
 		headerAdded = true
 
+		var stringBuilder strings.Builder
 		for _, obj := range ad.Objects {
-			output += "\n" + indent("- "+obj.String(), "\t")
+			stringBuilder.WriteString("\n" + indent("- "+obj.String(), "\t"))
 		}
+
+		output += stringBuilder.String()
 	}
 
 	if len(ad.extra) > 0 {
@@ -175,6 +178,8 @@ func (do *DataObject) String() string {
 
 	output += "\n  Objects:"
 
+	var stringBuilder strings.Builder
+
 	for _, point := range do.Points {
 		lines := strings.Split(point.String(), "\n")
 		if len(lines) > 0 {
@@ -183,9 +188,11 @@ func (do *DataObject) String() string {
 				lines[i] = "  " + lines[i]
 			}
 
-			output += "\n" + indent(strings.Join(lines, "\n"), "\t")
+			stringBuilder.WriteString("\n" + indent(strings.Join(lines, "\n"), "\t"))
 		}
 	}
+
+	output += stringBuilder.String()
 
 	return output
 }

--- a/dnp3/dataLink.go
+++ b/dnp3/dataLink.go
@@ -30,8 +30,14 @@ func (dl *DataLink) FromBytes(data []byte) error {
 	}
 
 	dl.Synchronize = [2]byte{0x05, 0x64}
+
 	dl.Length = uint16(data[2])
-	dl.Control.FromByte(data[3])
+
+	err := dl.Control.FromByte(data[3])
+	if err != nil {
+		return err
+	}
+
 	dl.Destination = binary.LittleEndian.Uint16(data[4:6])
 	dl.Source = binary.LittleEndian.Uint16(data[6:8])
 	dl.Checksum = [2]byte{data[8], data[9]}
@@ -52,7 +58,13 @@ func (dl *DataLink) ToBytes() ([]byte, error) {
 
 	out = append(out, dl.Synchronize[:]...)
 	out = append(out, byte(dl.Length))
-	out = append(out, dl.Control.ToByte())
+
+	ctlByte, err := dl.Control.ToByte()
+	if err != nil {
+		return nil, err
+	}
+
+	out = append(out, ctlByte)
 	out = binary.LittleEndian.AppendUint16(out, dl.Destination)
 	out = binary.LittleEndian.AppendUint16(out, dl.Source)
 
@@ -74,22 +86,48 @@ func (dl *DataLink) String() string {
 
 // DataLinkControl is the 4th byte of the data link header.
 type DataLinkControl struct {
-	Direction       bool                        `json:"direction"`
-	Primary         bool                        `json:"primary"`
-	FrameCountBit   bool                        `json:"frame_count_bit"`   // ignoring checks to enforce dl to 0
-	FrameCountValid bool                        `json:"frame_count_valid"` // ignoring use of DFC
-	FunctionCode    DataLinkPrimaryFunctionCode `json:"function_code"`     // only 4 bits
+	Direction       bool             `json:"direction"`
+	Primary         bool             `json:"primary"`
+	FrameCountBit   bool             `json:"frame_count_bit"`   // ignoring checks to enforce dl to 0
+	FrameCountValid bool             `json:"frame_count_valid"` // ignoring use of DFC
+	FunctionCode    DataLinkFunction `json:"function_code"`     // only 4 bits
 }
 
-func (dlctl *DataLinkControl) FromByte(value byte) {
+func (dlctl *DataLinkControl) FromByte(value byte) error {
 	dlctl.Direction = (value & 0b10000000) != 0
 	dlctl.Primary = (value & 0b01000000) != 0
 	dlctl.FrameCountBit = (value & 0b00100000) != 0
 	dlctl.FrameCountValid = (value & 0b00010000) != 0
-	dlctl.FunctionCode = DataLinkPrimaryFunctionCode(value & 0b00001111)
+
+	functionCode := value & 0b00001111
+	if dlctl.Primary {
+		code := DataLinkPrimaryFunctionCode(functionCode)
+		if !isValidPrimaryFunctionCode(code) {
+			return fmt.Errorf("unknown primary function code 0x%X", functionCode)
+		}
+
+		if !checkPrimaryFunctionCodeFCVValidity(code, dlctl.FrameCountValid) {
+			return fmt.Errorf(
+				"invalid FCV value %t for primary function code 0x%X",
+				dlctl.FrameCountValid,
+				functionCode,
+			)
+		}
+
+		dlctl.FunctionCode = code
+	} else {
+		code := DataLinkSecondaryFunctionCode(functionCode)
+		if !isValidSecondaryFunctionCode(code) {
+			return fmt.Errorf("unknown secondary function code 0x%X", functionCode)
+		}
+
+		dlctl.FunctionCode = code
+	}
+
+	return nil
 }
 
-func (dlctl *DataLinkControl) ToByte() byte {
+func (dlctl *DataLinkControl) ToByte() (byte, error) {
 	var controlByte byte
 
 	if dlctl.Direction {
@@ -108,12 +146,23 @@ func (dlctl *DataLinkControl) ToByte() byte {
 		controlByte |= 0b00010000
 	}
 
-	controlByte |= (uint8(dlctl.FunctionCode) & 0b00001111)
+	if dlctl.FunctionCode != nil {
+		controlByte |= (dlctl.FunctionCode.Byte() & 0b00001111)
+	}
 
-	return controlByte
+	return controlByte, nil
 }
 
 func (dlctl *DataLinkControl) String() string {
+	var codeVal byte
+
+	codeName := "n/a"
+
+	if dlctl.FunctionCode != nil {
+		codeVal = dlctl.FunctionCode.Byte()
+		codeName = dlctl.FunctionCode.String()
+	}
+
 	return fmt.Sprintf(
 		`CTL:
 	DIR: %t
@@ -125,16 +174,25 @@ func (dlctl *DataLinkControl) String() string {
 		dlctl.Primary,
 		dlctl.FrameCountBit,
 		dlctl.FrameCountValid,
-		dlctl.FunctionCode,
-		dlctl.FunctionCode.String(),
+		codeVal,
+		codeName,
 	)
+}
+
+type DataLinkFunction interface {
+	fmt.Stringer
+	Byte() byte
 }
 
 // DataLinkPrimaryFunctionCode - Function Codes for master to outsation
 // (PRM set).
 //
 //go:generate stringer -type=DataLinkPrimaryFunctionCode
-type DataLinkPrimaryFunctionCode uint8
+type DataLinkPrimaryFunctionCode byte
+
+func (fc DataLinkPrimaryFunctionCode) Byte() byte {
+	return byte(fc)
+}
 
 const (
 	ResetLinkStates     DataLinkPrimaryFunctionCode = 0x0 // FCV 0
@@ -144,11 +202,35 @@ const (
 	RequestLinkStatus   DataLinkPrimaryFunctionCode = 0x9 //     0
 )
 
+func isValidPrimaryFunctionCode(code DataLinkPrimaryFunctionCode) bool {
+	switch code {
+	case ResetLinkStates, TestLinkStates, ConfirmedUserData, UnconfirmedUserData, RequestLinkStatus:
+		return true
+	default:
+		return false
+	}
+}
+
+func checkPrimaryFunctionCodeFCVValidity(code DataLinkPrimaryFunctionCode, fcv bool) bool {
+	switch code {
+	case ResetLinkStates, UnconfirmedUserData, RequestLinkStatus:
+		return !fcv
+	case TestLinkStates, ConfirmedUserData:
+		return fcv
+	}
+
+	return false
+}
+
 // DataLinkSecondaryFunctionCode - Function Codes for outstation to master
 // (PRM unset).
 //
 //go:generate stringer -type=DataLinkSecondaryFunctionCode
-type DataLinkSecondaryFunctionCode uint8
+type DataLinkSecondaryFunctionCode byte
+
+func (fc DataLinkSecondaryFunctionCode) Byte() byte {
+	return byte(fc)
+}
 
 const (
 	Ack          DataLinkSecondaryFunctionCode = 0x0
@@ -156,3 +238,12 @@ const (
 	LinkStatus   DataLinkSecondaryFunctionCode = 0xb
 	NotSupported DataLinkSecondaryFunctionCode = 0xf
 )
+
+func isValidSecondaryFunctionCode(code DataLinkSecondaryFunctionCode) bool {
+	switch code {
+	case Ack, Nack, LinkStatus, NotSupported:
+		return true
+	default:
+		return false
+	}
+}

--- a/dnp3/point.go
+++ b/dnp3/point.go
@@ -71,6 +71,7 @@ func newPoints1Bit(data []byte, num, prefSize int) ([]Point, int, error) {
 
 func packerPoints1Bit(points []Point) ([]byte, error) {
 	var packed []byte
+
 	for pointOffset := 0; pointOffset < len(points); pointOffset += 8 {
 		var packedByte byte
 
@@ -236,6 +237,7 @@ func newPoints2Bits(data []byte, num, prefSize int) ([]Point, int, error) {
 
 func packerPoints2Bits(points []Point) ([]byte, error) {
 	var packed []byte
+
 	for pointOffset := 0; pointOffset < len(points); pointOffset += 4 {
 		var packedByte byte
 
@@ -305,10 +307,6 @@ type PointNBytesFlags struct {
 }
 
 func (p *PointNBytesFlags) FromBytes(data []byte, prefSize int) error {
-	if len(data) != 2+prefSize {
-		return fmt.Errorf("need %d bytes, got %d", 2+prefSize, len(data))
-	}
-
 	if prefSize != 0 {
 		p.Prefix = data[0:prefSize]
 	}


### PR DESCRIPTION
* Minor changes to `make setup`, `test`
* DataLink Function codes now include Secondary (previously implemented but not used)
* removed incorrect size check in PointNBytes