### PR TITLE
feat: multi-frame parsing, extra accessors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libpcap-dev
       - uses: golangci/golangci-lint-action@v9
         with:
-          version: v2.10.1
+          version: v2.12.1
 
   codespell:
     runs-on: ubuntu-latest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - bidichk
     - bodyclose
     - canonicalheader
+    - clickhouselint
     - containedctx
     - contextcheck
     - copyloopvar
@@ -36,12 +37,12 @@ linters:
     - goconst
     - gocritic
     - gocyclo
-    # - godoclint
+    - godoclint
     - godot
     - godox
     - goheader
     - gomoddirectives
-    - gomodguard
+    - gomodguard_v2
     - goprintffuncname
     - gosec
     - gosmopolitan
@@ -60,7 +61,7 @@ linters:
     - makezero
     - mirror
     - misspell
-    # - mnd
+    - modernize
     - musttag
     - nakedret
     - nestif
@@ -129,21 +130,15 @@ linters:
       # Maybe one day
       - linters:
           - revive
-        text: "should have comment or be unexported"
-      - linters:
-          - revive 
-        text: "exported: "
+        text: "should have comment"
 
   disable:
-    # Never
     - depguard         # requires manual config of imports
     - interfacebloat   # limits interfaces to 10 methods
     - err113           # does not allow dynamic error
     - exhaustruct      # does not allow empty struct initialization (something something OOP)
     - gochecknoglobals # does not allow globals
     - mnd              # does not allow magic numbers which is everywhere in protocol parsing
-    # Maybe one day
-    - godoclint        # re-add eventually (revive comment/unexported too)
 
 formatters:
   enable:

--- a/dnp3/applicationData.go
+++ b/dnp3/applicationData.go
@@ -14,6 +14,24 @@ type ApplicationData struct {
 	extra []byte
 }
 
+// NewApplicationData returns a new ApplicationData ready to be populated via
+// FromBytes or by setting fields directly.
+func NewApplicationData() *ApplicationData {
+	return &ApplicationData{}
+}
+
+// NewApplicationDataFromBytes returns a new ApplicationData parsed from the given bytes.
+func NewApplicationDataFromBytes(data []byte) (*ApplicationData, error) {
+	appData := &ApplicationData{}
+
+	err := appData.FromBytes(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return appData, nil
+}
+
 func (ad *ApplicationData) FromBytes(data []byte) error {
 	ad.Objects = nil // in case there was already stuff here
 
@@ -84,12 +102,38 @@ func (ad *ApplicationData) HasExtra() bool {
 	return len(ad.extra) > 0
 }
 
+func (ad *ApplicationData) GetExtra() []byte {
+	return ad.extra
+}
+
+func (ad *ApplicationData) SetExtra(extra []byte) {
+	ad.extra = extra
+}
+
 type DataObject struct {
 	Header    ObjectHeader `json:"header"`
 	Points    []Point      `json:"points"`
 	Extra     []byte       `json:"extra,omitempty"`
 	totalSize int
 	indexes   []int
+}
+
+// NewDataObject returns a new DataObject ready to be populated via FromBytes
+// or by setting fields directly.
+func NewDataObject() *DataObject {
+	return &DataObject{}
+}
+
+// NewDataObjectFromBytes returns a new DataObject parsed from the given bytes.
+func NewDataObjectFromBytes(data []byte) (*DataObject, error) {
+	dataObj := &DataObject{}
+
+	err := dataObj.FromBytes(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return dataObj, nil
 }
 
 func (do *DataObject) FromBytes(data []byte) error {

--- a/dnp3/dnp3.go
+++ b/dnp3/dnp3.go
@@ -39,7 +39,59 @@ func NewFrameFromBytes(data []byte) (*Frame, error) {
 	return frame, nil
 }
 
-// DNP3Type (required by gopacket).
+// ParseFrames parses all complete DNP3 frames from data.
+// It returns the parsed frames, any unconsumed trailing bytes
+// (a partial frame), and the first error encountered.
+// On error, frames parsed before the error are also returned.
+func ParseFrames(data []byte) ([]*Frame, []byte, error) {
+	var frames []*Frame
+
+	pos := 0
+	for pos < len(data) {
+		remaining := data[pos:]
+		if len(remaining) < 10 {
+			return frames, remaining, nil
+		}
+
+		total := frameWireSize(remaining[2])
+		if total == 0 {
+			return frames, remaining, fmt.Errorf(
+				"invalid DNP3 length byte %d at offset %d",
+				remaining[2],
+				pos,
+			)
+		}
+
+		if len(remaining) < total {
+			return frames, remaining, nil
+		}
+
+		frame, err := NewFrameFromBytes(remaining[:total])
+		if err != nil {
+			return frames, remaining, err
+		}
+
+		frames = append(frames, frame)
+		pos += total
+	}
+
+	return frames, nil, nil
+}
+
+// frameWireSize returns the total number of on-wire bytes for a DNP3 frame
+// whose DataLink Length field equals lengthByte. Returns 0 for invalid lengths.
+func frameWireSize(lengthByte byte) int {
+	if lengthByte < 5 {
+		return 0
+	}
+
+	payloadLen := int(lengthByte) - 5
+	numBlocks := (payloadLen + 15) / 16
+
+	return 10 + payloadLen + numBlocks*2
+}
+
+// LayerTypeDNP3 is the gopacket layer type for DNP3 (required by gopacket).
 var LayerTypeDNP3 = gopacket.RegisterLayerType(20000,
 	gopacket.LayerTypeMetadata{
 		Name:    "DNP3",
@@ -47,12 +99,12 @@ var LayerTypeDNP3 = gopacket.RegisterLayerType(20000,
 	},
 )
 
-// DNP3Layer type (required by gopacket).
+// LayerType returns the gopacket layer type for DNP3 (required by gopacket).
 func (*Frame) LayerType() gopacket.LayerType {
 	return LayerTypeDNP3
 }
 
-// All DNP3 layer bytes (required by gopacket).
+// LayerContents returns all DNP3 layer bytes (required by gopacket).
 func (dnp *Frame) LayerContents() []byte {
 	encodedPacket, err := dnp.ToBytes()
 	if err != nil {
@@ -64,7 +116,7 @@ func (dnp *Frame) LayerContents() []byte {
 	return encodedPacket
 }
 
-// DNP3 application object bytes (required by gopacket).
+// LayerPayload returns the DNP3 application object bytes (required by gopacket).
 func (dnp *Frame) LayerPayload() []byte {
 	applicationPayload, err := dnp.Application.ToBytes()
 	if err != nil {
@@ -113,8 +165,18 @@ func (dnp *Frame) FromBytes(data []byte) error {
 		return nil
 	}
 
-	// Make transport and remove CRCs
-	clean, err = dnp.Transport.FromBytes(data[10:])
+	// Make transport and remove CRCs. Slice to the frame boundary so a second
+	// frame in the same buffer cannot corrupt CRC validation.
+	payloadLen := int(dnp.DataLink.Length) - 5
+	numBlocks := (payloadLen + 15) / 16
+	framePayloadBytes := payloadLen + numBlocks*2
+
+	transportData := data[10:]
+	if payloadLen > 0 && len(transportData) > framePayloadBytes {
+		transportData = transportData[:framePayloadBytes]
+	}
+
+	clean, err = dnp.Transport.FromBytes(transportData)
 	if err != nil {
 		return fmt.Errorf("error in DNP3 Transport layer: %w", err)
 	}

--- a/dnp3/dnp3_test.go
+++ b/dnp3/dnp3_test.go
@@ -211,7 +211,7 @@ func testFromBytesToBytesStringMarshal(t *testing.T, input []byte) {
 func splitComma(s string) []string {
 	var out []string
 
-	for _, v := range strings.Split(s, ",") {
+	for v := range strings.SplitSeq(s, ",") {
 		v = strings.TrimSpace(v)
 		if v != "" {
 			out = append(out, v)
@@ -219,4 +219,173 @@ func splitComma(s string) []string {
 	}
 
 	return out
+}
+
+// readBinaryInputChange is a 18-byte frame used across ParseFrames tests.
+var readBinaryInputChange = []byte{
+	0x05, 0x64, 0x0b, 0xc4, 0x00, 0x04, 0x01, 0x00,
+	0xca, 0x8a, 0xc0, 0xc1, 0x01, 0x02, 0x00, 0x06,
+	0x95, 0x76,
+}
+
+// readClass1230 is a 27-byte frame used across ParseFrames tests.
+var readClass1230 = []byte{
+	0x05, 0x64, 0x14, 0xc4, 0x04, 0x00, 0x03, 0x00,
+	0xc7, 0x17, 0xc4, 0xc5, 0x01, 0x3c, 0x02, 0x06,
+	0x3c, 0x03, 0x06, 0x3c, 0x04, 0x06, 0x3c, 0x01,
+	0x06, 0xa3, 0x61,
+}
+
+func TestParseFrames_empty(t *testing.T) {
+	t.Parallel()
+
+	frames, remainder, err := dnp3.ParseFrames(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(frames) != 0 {
+		t.Fatalf("expected 0 frames, got %d", len(frames))
+	}
+
+	if len(remainder) != 0 {
+		t.Fatalf("expected empty remainder, got %d bytes", len(remainder))
+	}
+}
+
+func TestParseFrames_single(t *testing.T) {
+	t.Parallel()
+
+	frames, remainder, err := dnp3.ParseFrames(readBinaryInputChange)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(frames) != 1 {
+		t.Fatalf("expected 1 frame, got %d", len(frames))
+	}
+
+	if len(remainder) != 0 {
+		t.Fatalf("expected empty remainder, got %d bytes", len(remainder))
+	}
+}
+
+func TestParseFrames_two(t *testing.T) {
+	t.Parallel()
+
+	input := append(slices.Clone(readBinaryInputChange), readClass1230...)
+
+	frames, remainder, err := dnp3.ParseFrames(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(frames) != 2 {
+		t.Fatalf("expected 2 frames, got %d", len(frames))
+	}
+
+	if len(remainder) != 0 {
+		t.Fatalf("expected empty remainder, got %d bytes", len(remainder))
+	}
+}
+
+func TestParseFrames_partialHeader(t *testing.T) {
+	t.Parallel()
+
+	// First frame complete; trailing 5 bytes are a partial header.
+	partial := readClass1230[:5]
+	input := append(slices.Clone(readBinaryInputChange), partial...)
+
+	frames, remainder, err := dnp3.ParseFrames(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(frames) != 1 {
+		t.Fatalf("expected 1 frame, got %d", len(frames))
+	}
+
+	if !slices.Equal(remainder, partial) {
+		t.Fatalf("expected remainder %x, got %x", partial, remainder)
+	}
+}
+
+func TestParseFrames_partialBody(t *testing.T) {
+	t.Parallel()
+
+	// First frame complete; trailing bytes have a valid header but incomplete body.
+	partial := readClass1230[:12] // 10-byte header + 2 body bytes, needs 27 total
+	input := append(slices.Clone(readBinaryInputChange), partial...)
+
+	frames, remainder, err := dnp3.ParseFrames(input)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(frames) != 1 {
+		t.Fatalf("expected 1 frame, got %d", len(frames))
+	}
+
+	if !slices.Equal(remainder, partial) {
+		t.Fatalf("expected remainder %x, got %x", partial, remainder)
+	}
+}
+
+// TestFromBytes_concatenatedFrames is a regression test for the CRC-corruption
+// bug: passing two frames in one buffer must not corrupt the first frame's CRC
+// validation.
+func TestFromBytes_concatenatedFrames(t *testing.T) {
+	t.Parallel()
+
+	// Two valid frames concatenated in a single buffer.
+	buf := append(slices.Clone(readBinaryInputChange), readClass1230...)
+
+	frame, err := dnp3.NewFrameFromBytes(buf)
+	if err != nil {
+		t.Fatalf("FromBytes failed on concatenated buffer: %v", err)
+	}
+
+	// Re-encode and compare only the first frame's bytes.
+	got, err := frame.ToBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !slices.Equal(got, readBinaryInputChange) {
+		t.Fatalf("re-encoded frame mismatch\nwant: %x\n got: %x", readBinaryInputChange, got)
+	}
+}
+
+func TestApplicationData_GetSetExtra(t *testing.T) {
+	t.Parallel()
+
+	appData := dnp3.NewApplicationData()
+	if appData.HasExtra() {
+		t.Fatal("new ApplicationData should have no extra")
+	}
+
+	if appData.GetExtra() != nil {
+		t.Fatal("GetExtra should return nil when not set")
+	}
+
+	extra := []byte{0xDE, 0xAD, 0xBE, 0xEF}
+	appData.SetExtra(extra)
+
+	if !appData.HasExtra() {
+		t.Fatal("HasExtra should be true after SetExtra")
+	}
+
+	if !slices.Equal(appData.GetExtra(), extra) {
+		t.Fatalf("GetExtra returned %x, want %x", appData.GetExtra(), extra)
+	}
+
+	// ToBytes should include the extra bytes in output.
+	out, err := appData.ToBytes()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !slices.Equal(out, extra) {
+		t.Fatalf("ToBytes returned %x, want %x", out, extra)
+	}
 }

--- a/dnp3/objectHeader.go
+++ b/dnp3/objectHeader.go
@@ -19,6 +19,24 @@ type ObjectHeader struct {
 	size            int
 }
 
+// NewObjectHeader returns a new ObjectHeader ready to be populated via FromBytes
+// or by setting fields directly.
+func NewObjectHeader() *ObjectHeader {
+	return &ObjectHeader{}
+}
+
+// NewObjectHeaderFromBytes returns a new ObjectHeader parsed from the given bytes.
+func NewObjectHeaderFromBytes(data []byte) (*ObjectHeader, error) {
+	objHeader := &ObjectHeader{}
+
+	err := objHeader.FromBytes(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return objHeader, nil
+}
+
 func (oh *ObjectHeader) FromBytes(data []byte) error {
 	if len(data) < 3 {
 		return fmt.Errorf("object headers are at 3 - 11 bytes, got %d", len(data))

--- a/dnp3/point2Bits.go
+++ b/dnp3/point2Bits.go
@@ -13,7 +13,7 @@ type Point2Bits struct {
 
 func (p *Point2Bits) DataType() PointDataType { return PointDataType2Bits }
 
-// should not be used directly.
+// FromBytes should not be used directly.
 func (p *Point2Bits) FromBytes(data []byte, prefSize int) error {
 	if len(data) > 1 {
 		return errors.New("can't construct 2 bit point from multiple bytes")
@@ -29,7 +29,7 @@ func (p *Point2Bits) FromBytes(data []byte, prefSize int) error {
 	return nil
 }
 
-// should not be used directly.
+// ToBytes should not be used directly.
 func (p *Point2Bits) ToBytes() ([]byte, error) {
 	var packedValue byte
 	if p.Value[0] {

--- a/dnp3/pointBit.go
+++ b/dnp3/pointBit.go
@@ -22,7 +22,7 @@ type PointBit struct {
 
 func (p *PointBit) DataType() PointDataType { return PointDataTypeBit }
 
-// should not be used directly for packed (non-flags) points.
+// FromBytes should not be used directly for packed (non-flags) points.
 func (p *PointBit) FromBytes(data []byte, prefSize int) error {
 	if p.hasFlags {
 		return p.fromBytesFlags(data, prefSize)
@@ -39,7 +39,7 @@ func (p *PointBit) FromBytes(data []byte, prefSize int) error {
 	return nil
 }
 
-// should not be used directly for packed (non-flags) points.
+// ToBytes should not be used directly for packed (non-flags) points.
 func (p *PointBit) ToBytes() ([]byte, error) {
 	if p.hasFlags {
 		return p.toBytesFlags()

--- a/dnp3/pointBytes.go
+++ b/dnp3/pointBytes.go
@@ -404,14 +404,14 @@ func (p *PointBytes) encodeField(field pointField) ([]byte, error) {
 			return nil, errors.New("absolute time field is required by layout but is nil")
 		}
 
-		return DNP3TimeAbsoluteToBytes(*p.AbsoluteTime)
+		return TimeAbsoluteToBytes(*p.AbsoluteTime)
 
 	case pointFieldRelTime:
 		if p.RelativeTime == nil {
 			return nil, errors.New("relative time field is required by layout but is nil")
 		}
 
-		return DNP3TimeRelativeToBytes(*p.RelativeTime)
+		return TimeRelativeToBytes(*p.RelativeTime)
 
 	case pointFieldValue:
 		return p.encodeFieldValue(), nil
@@ -474,13 +474,7 @@ func newPointBytesWithLayout(layout pointBytesLayout, width int) func() *PointBy
 
 	calculatedExpectedValueSize := 0
 	if layout.hasField(pointFieldValue) {
-		calculatedExpectedValueSize = width - fixedFieldsWidth
-		if calculatedExpectedValueSize < 0 {
-			// This should not happen if width is correctly calculated in objectType.go
-			// but as a safeguard, we can set it to 0 or return an error.
-			// For now, let's assume it means no specific value size is expected.
-			calculatedExpectedValueSize = 0
-		}
+		calculatedExpectedValueSize = max(width-fixedFieldsWidth, 0)
 	}
 
 	return func() *PointBytes {

--- a/dnp3/response.go
+++ b/dnp3/response.go
@@ -38,7 +38,7 @@ func (appresp *ApplicationResponse) FromBytes(data []byte) error {
 
 	appresp.FunctionCode = ResponseFunctionCode(data[1])
 
-	err := appresp.InternalIndications.FromBytes(data[2], data[3])
+	err := appresp.InternalIndications.FromBytes(data[2:4])
 	if err != nil {
 		return fmt.Errorf("can't create application response: %w", err)
 	}
@@ -157,7 +157,37 @@ type ApplicationInternalIndications struct {
 	Reserved2        bool `json:"reserved_2"` // ^
 }
 
-func (appiin *ApplicationInternalIndications) FromBytes(lsb, msb byte) error {
+// NewApplicationInternalIndications returns a new ApplicationInternalIndications
+// ready to be populated via FromBytes or by setting fields directly.
+func NewApplicationInternalIndications() *ApplicationInternalIndications {
+	return &ApplicationInternalIndications{}
+}
+
+// NewApplicationInternalIndicationsFromBytes returns a new
+// ApplicationInternalIndications parsed from the given bytes.
+func NewApplicationInternalIndicationsFromBytes(
+	data []byte,
+) (*ApplicationInternalIndications, error) {
+	appiin := &ApplicationInternalIndications{}
+
+	err := appiin.FromBytes(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return appiin, nil
+}
+
+func (appiin *ApplicationInternalIndications) FromBytes(data []byte) error {
+	if len(data) != 2 {
+		return fmt.Errorf(
+			"ApplicationInternalIndications requires exactly 2 bytes, got %d",
+			len(data),
+		)
+	}
+
+	lsb, msb := data[0], data[1]
+
 	appiin.AllStations = (lsb & 0b00000001) != 0
 	appiin.Class1Events = (lsb & 0b00000010) != 0
 	appiin.Class2Events = (lsb & 0b00000100) != 0

--- a/dnp3/util.go
+++ b/dnp3/util.go
@@ -184,7 +184,7 @@ func BytesToDNP3TimeAbsolute(data []byte) (AbsoluteTime, error) {
 	return AbsoluteTime(time.UnixMilli(int64(milliseconds))), nil
 }
 
-func DNP3TimeAbsoluteToBytes(value AbsoluteTime) ([]byte, error) {
+func TimeAbsoluteToBytes(value AbsoluteTime) ([]byte, error) {
 	milliseconds := value.Time().UnixMilli()
 	if milliseconds < 0 {
 		return nil, fmt.Errorf("timestamp %v is negative", value)
@@ -211,7 +211,7 @@ func BytesToDNP3TimeRelative(data []byte) (RelativeTime, error) {
 	return RelativeTime(time.Duration(milliseconds) * time.Millisecond), nil
 }
 
-func DNP3TimeRelativeToBytes(relativeTime RelativeTime) ([]byte, error) {
+func TimeRelativeToBytes(relativeTime RelativeTime) ([]byte, error) {
 	relativeDuration := relativeTime.Duration()
 	milliseconds := int64(relativeDuration / time.Millisecond)
 
@@ -230,7 +230,7 @@ func DNP3TimeRelativeToBytes(relativeTime RelativeTime) ([]byte, error) {
 func indent(s, prefix string) string {
 	var lines []string
 
-	for _, line := range strings.Split(s, "\n") {
+	for line := range strings.SplitSeq(s, "\n") {
 		if line != "" {
 			lines = append(lines, prefix+line)
 		} else {

--- a/example.go
+++ b/example.go
@@ -21,7 +21,22 @@ func main() {
 		0x64, 0x71, 0x01, 0x38, 0x5d,
 	}
 
-	// Parse the input bytes into a DNP3 Frame
+	// ParseFrames handles raw TCP reads that may contain multiple DNP3 frames
+	// or a trailing partial frame. It returns all complete frames and any
+	// unconsumed bytes so the caller can prepend them to the next read.
+	tcpSegment := append(input, input...) // two frames in one segment
+	frames, remainder, err := dnp3.ParseFrames(tcpSegment)
+	if err != nil {
+		log.Fatalf("Failed to parse frames: %v", err)
+	}
+
+	fmt.Printf("--- ParseFrames: %d frame(s), %d remainder byte(s) ---\n", len(frames), len(remainder))
+
+	for i, f := range frames {
+		fmt.Printf("Frame %d:\n%s\n", i+1, f.String())
+	}
+
+	// Parse the input bytes into a single DNP3 Frame
 	frame, err := dnp3.NewFrameFromBytes(input)
 	if err != nil {
 		log.Fatalf("Failed to parse frame: %v", err)


### PR DESCRIPTION
* Fix Frame.FromBytes CRC corruption when multiple DNP3 frames are concatenated in one TCP segment
* Add ParseFrames for parsing complete frames from a raw TCP read with partial-frame remainder support
* Add GetExtra/SetExtra accessors on ApplicationData
* Enable godoclint, modernize, clickhouselint; account for all available linters
* Rename DNP3TimeAbsoluteToBytes/DNP3TimeRelativeToBytes to drop stutter prefix